### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/index.md
+++ b/index.md
@@ -16,7 +16,7 @@ postal-code:
 
 OWASP Pune
 ----------
-Welcome to the Pune chapter homepage. The Open Web Application Security Project (OWASP) is a nonprofit foundation that works to improve the security of software. All of our projects ,tools, documents, forums, and chapters are free and open to anyone interested in improving application security. The chapter leaders are <a href="mailto:jyoti.raval@owasp.org">Jyoti Raval</a> , <a href="mailto:pramod.rana@owasp.org">Pramod Rana</a> and <a href="mailto:prasad.salvi@owasp.org">Prasad Salvi</a>.
+Welcome to the Pune chapter homepage. The Open Worldwide Application Security Project (OWASP) is a nonprofit foundation that works to improve the security of software. All of our projects ,tools, documents, forums, and chapters are free and open to anyone interested in improving application security. The chapter leaders are <a href="mailto:jyoti.raval@owasp.org">Jyoti Raval</a> , <a href="mailto:pramod.rana@owasp.org">Pramod Rana</a> and <a href="mailto:prasad.salvi@owasp.org">Prasad Salvi</a>.
 Follow chapter news on [Linkedin](https://www.linkedin.com/groups/7022347) \| [Twitter](https://twitter.com/owasp_pune) \| [Meetup](https://www.meetup.com/OWASP-Pune-Chapter) \| [Telegram](https://t.me/joinchat/LYupoRTKnq2jU6cjXKlxAg)
 
 ## Upcoming Meeting:


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)